### PR TITLE
Fix hard error when checking if non-common-range is printable

### DIFF
--- a/interpreter/cling/include/cling/Interpreter/RuntimePrintValue.h
+++ b/interpreter/cling/include/cling/Interpreter/RuntimePrintValue.h
@@ -203,7 +203,8 @@ namespace cling {
         typename std::enable_if<
             std::is_reference<decltype(*std::begin(*obj))>::value>::type* = 0)
         -> decltype(std::end(*obj), std::string()) {
-      auto iter = obj->begin(), iterEnd = obj->end();
+      auto iter = obj->begin();
+      auto iterEnd = obj->end();
       if (iter == iterEnd) return valuePrinterInternal::kEmptyCollection;
 
       const void* M = TypeTest::isMap(obj);
@@ -224,7 +225,8 @@ namespace cling {
         typename std::enable_if<
             !std::is_reference<decltype(*(obj->begin()))>::value>::type* = 0)
         -> decltype(++(obj->begin()), obj->end(), std::string()) {
-      auto iter = obj->begin(), iterEnd = obj->end();
+      auto iter = obj->begin();
+      auto iterEnd = obj->end();
       if (iter == iterEnd) return valuePrinterInternal::kEmptyCollection;
 
       std::string str("{ ");


### PR DESCRIPTION


# This Pull request:

## Changes or fixes:
Fix hard error when checking non-common-range. I.e., [std::ranges::enumerate_view](https://en.cppreference.com/w/cpp/ranges/enumerate_view).
Although root does not support C++20 currently, a range that returns different type for `begin()` and `end()` is legal in other C++ versions.


## Checklist:

- [x] tested changes locally
- [ ] updated the docs (if necessary)

This PR fixes # 
https://github.com/root-project/root/issues/14966

